### PR TITLE
Install missing setuptools-scm dependency in pypi deploy workflow

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python --version
-          pip install -U pip setuptools wheel
+          pip install -U pip setuptools wheel setuptools_scm[toml]
           python setup.py sdist bdist_wheel
 
       - name: Publish package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools >= 40.6.0", "wheel", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools >= 45", "wheel", "setuptools_scm[toml]>=6.0"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "matplotlib",
         "scipy",
         "ipython",
-        "setuptools_scm>=3.4"
+        "setuptools_scm"
     ],
     package_data={
         'showermodel': [


### PR DESCRIPTION
`setuptools_scm` was not being installed in the publishing to pypi github workflow. Hence it always was producing the package with version 0.0.0