### PR TITLE
Remove gh accion for building and deploying the docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,30 +35,3 @@ jobs:
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: true
-
-  docs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: git fetch --tags
-
-      - name: Sphinx Build
-        uses: ammaraskar/sphinx-action@0.4
-        with:
-          docs-folder: "docs/"
-          pre-build-command: |
-            apt update --yes && apt install --yes git build-essential pandoc graphviz
-            pip install -U pip setuptools wheel
-            pip install -e .[docs]
-            python -c 'import showermodel; print(showermodel.__version__)'
-
-      - name: Deploy to gihub pages
-        # only run on push to master
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        uses: JamesIves/github-pages-deploy-action@3.7.1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: docs/_build/html
-          CLEAN: true
-          SINGLE_COMMIT: true

--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
-ShowerModel
---------
+# ShowerModel
 
-![ShowerModel logo](docs/logo_showermodel.png)
-
+[![Build Status](https://github.com/JaimeRosado/ShowerModel/workflows/CI/badge.svg?branch=master)](https://github.com/JaimeRosado/ShowerModel/actions?query=workflow%3ACI+branch%3Amaster)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/JaimeRosado/ShowerModel/master?filepath=notebooks)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4727298.svg)](https://doi.org/10.5281/zenodo.4727298)
-[![image](https://img.shields.io/pypi/v/ShowerModel.svg)](https://pypi.org/project/ShowerModel)
-[![image](https://github.com/JaimeRosado/ShowerModel/workflows/CI/badge.svg?branch=master)](https://github.com/JaimeRosado/ShowerModel/actions?query=workflow%3ACI+branch%3Amaster)
+[![pypi](https://img.shields.io/pypi/v/ShowerModel.svg)](https://pypi.org/project/ShowerModel)
+[![Documentation Status](https://readthedocs.org/projects/showermodel/badge/?version=latest)](https://showermodel.readthedocs.io/en/latest/?badge=latest)
 
+![ShowerModel logo](docs/logo_showermodel.png)
 
 A Python package for modelling cosmic-ray showers, their light production and their detection.
 
 --------
 * Code : https://github.com/JaimeRosado/ShowerModel
-* Docs: https://jaimerosado.github.io/ShowerModel
+* Docs: https://showermodel.readthedocs.io/
 * License: GPL-3.0
 --------
 
@@ -58,8 +57,6 @@ pip install -e .
 Test your installation by running any of the notebooks in this repository.
 Otherwise, open an Issue with your error.
 
-Installation, versioning and docs-web deploying methods are base on 
-the [*ctapipe* repository](https://github.com/cta-observatory/ctapipe).
 
 ## Further information
 See our presentation video and poster from ADASS XXX conference https://adass2020.es/:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,8 +3,8 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    = -W --keep-going -n --color
-SPHINXBUILD   = sphinx-build
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,13 +6,15 @@
 ShowerModel
 =======================================
 
+**version**:  |version|
+
 .. figure:: logo_showermodel.png
     :align: center
 
 A Python package for modelling cosmic-ray showers, their light production and its detection.
 
 * Code: https://github.com/JaimeRosado/ShowerModel/
-* Docs: https://jaimerosado.github.io/ShowerModel/
+* Docs: https://showermodel.readthedocs.io/
 * License: BSD-3
 * Python 3.7 or later
 
@@ -22,6 +24,8 @@ A Python package for modelling cosmic-ray showers, their light production and it
     :caption: Guide
 
     introduction
+    tutorials/index
+    package/package
     bibliography
 
 

--- a/docs/package/signal.rst
+++ b/docs/package/signal.rst
@@ -4,6 +4,7 @@ Signal
 ===================
 
 .. automodule:: showermodel.signal
+   :noindex:
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/package/telescope.rst
+++ b/docs/package/telescope.rst
@@ -4,6 +4,7 @@ Telescope
 ===================
 
 .. automodule:: showermodel.telescope
+   :noindex:
    :members:
    :undoc-members:
    :show-inheritance:

--- a/showermodel/shower.py
+++ b/showermodel/shower.py
@@ -189,7 +189,7 @@ class Shower:
             Include the telescope efficiency. If False, 100% efficiency is
             assumed for a given wavelength interval.
         **kwargs {wvl_ini, wvl_fin, wvl_step}
-            These parameters will modify the wavelenght interval when
+            These parameters will modify the wavelength interval when
             tel_eff==False. If None, the wavelength interval defined in the
             telescope is used.
 

--- a/showermodel/signal.py
+++ b/showermodel/signal.py
@@ -1,9 +1,10 @@
 # coding: utf-8
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+
 import showermodel as sm
-import matplotlib.pyplot as plt
 
 
 # Class #######################################################################
@@ -44,7 +45,7 @@ class Signal(pd.DataFrame):
         Column 2, total number of photoelectrons per discretization step.
     telescope : Telescope object.
     atm_trans : bool
-        True if the atmospheric transmision is included.
+        True if the atmospheric transmission is included.
     tel_eff : bool
         True if the telescope efficiency is included.
     wvl_ini : float
@@ -85,7 +86,7 @@ class Signal(pd.DataFrame):
                  tel_eff=True, **kwargs):
         super().__init__(columns=['Npe_cher', 'Npe_fluo', 'Npe_total'])
         _signal(self, telescope, shower, projection, atm_trans, tel_eff,
-            **kwargs)
+                **kwargs)
 
     def show_projection(self, shower_size=True, axes=True, max_theta=30.,
                         X_mark='X_max'):
@@ -208,7 +209,7 @@ def _show(signal):
     fluo_time = np.array(signal.Npe_fluo / Delta_time)
     total_time = cher_time + fluo_time
 
-    # Number of photoelectrons due to each light componente (and total) per
+    # Number of photoelectrons due to each light component (and total) per
     # unit of beta angle
     Delta_beta = np.degrees(track.dl / distance * np.sin(np.radians(beta)))
     cher_beta = np.array(signal.Npe_cher / Delta_beta)
@@ -248,7 +249,7 @@ def _show(signal):
     ax2.legend(loc=0)
     plt.tight_layout()
 
-    return (ax1, ax2)
+    return ax1, ax2
 
 
 # Constructor #################################################################
@@ -265,12 +266,12 @@ def _signal(signal, telescope, shower, projection, atm_trans, tel_eff,
     projection : Projection object
         If None, it will generated from telescope and shower.
     atm_trans : bool, default True
-        Include the atmospheric transmision to transport photons.
+        Include the atmospheric transmission to transport photons.
     tel_eff : bool, default True
         Include the telescope efficiency to calculate the signal. If False,
-        100% efficiency is assumed for a given wavelenght interval.
+        100% efficiency is assumed for a given wavelength interval.
     **kwargs {wvl_ini, wvl_fin, wvl_step}
-        These parameters will modify the wavelenght interval when
+        These parameters will modify the wavelength interval when
         tel_eff==False. If None, the wavelength interval defined in the
         telescope is used.
     """
@@ -305,7 +306,7 @@ def _signal(signal, telescope, shower, projection, atm_trans, tel_eff,
     signal.tel_eff = tel_eff
 
     if tel_eff:
-        # Wavelenght range to calculate the signal
+        # Wavelength range to calculate the signal
         wvl_ini = telescope.wvl_ini
         wvl_fin = telescope.wvl_fin
         wvl_step = telescope.wvl_step
@@ -313,7 +314,7 @@ def _signal(signal, telescope, shower, projection, atm_trans, tel_eff,
         eff_fluo = telescope.eff_fluo
         eff_cher = telescope.eff_cher
     else:
-        # User-defined wavalength range
+        # User-defined wavelength range
         wvl_ini = kwargs.get('wvl_ini', telescope.wvl_ini)
         wvl_fin = kwargs.get('wvl_fin', telescope.wvl_fin)
         wvl_step = kwargs.get('wvl_step', telescope.wvl_step)
@@ -323,7 +324,7 @@ def _signal(signal, telescope, shower, projection, atm_trans, tel_eff,
     signal.wvl_step = wvl_step
 
     # Only discretization points within the telescope field of view contributes
-    # to the signal. In addition, the very begninning of the shower profile is
+    # to the signal. In addition, the very beginning of the shower profile is
     # ignored to speed up calculations
     points = projection[projection.FoV & (signal.profile.s > 0.01)].index
     distance = np.array(projection.distance.loc[points])
@@ -352,7 +353,7 @@ def _signal(signal, telescope, shower, projection, atm_trans, tel_eff,
     rel_fluo = fluorescence.loc[points]
     if tel_eff:
         rel_fluo *= eff_fluo  # 34 bands
-    # Selection of bands within the wavelenght range
+    # Selection of bands within the wavelength range
     rel_fluo = rel_fluo.loc[:, wvl_ini:wvl_fin]
 
     if atm_trans:
@@ -373,7 +374,7 @@ def _signal(signal, telescope, shower, projection, atm_trans, tel_eff,
         for wvl in rel_fluo:
             rel_fluo[wvl] *= trans ** ((350. / wvl)**4)
 
-        # Wavelenght factor for Cherenkov contribution to signal from each
+        # Wavelength factor for Cherenkov contribution to signal from each
         # shower point
         wvl_factor = pd.DataFrame(index=points)
         for wvl in wvl_cher:

--- a/showermodel/telescope.py
+++ b/showermodel/telescope.py
@@ -65,9 +65,9 @@ class Telescope:
         Integration time in microseconds of camera frames.
         Default to 0.01 us.
     sol_angle : float
-        Telescope field of view in stereoradians.
+        Telescope field of view in steradians.
     sol_angle_pix : float
-        Pixel field of view in steresorians.
+        Pixel field of view in steradians.
     apert_pix : float
         Angular diameter in degrees of the pixel FoV.
     wvl_ini : float
@@ -84,7 +84,7 @@ class Telescope:
         included in the model. See Fluorescence class.
     eff_fluo : ndarray
         Array containing the detection efficiency at these 34
-        wavelenghts. Default to 1.
+        wavelengths. Default to 1.
     wvl_cher : ndarray
         Array containing the range of wavelengths in nm defined by
         wvl_ini, wvl_fin and wvl_step
@@ -579,7 +579,7 @@ class IACT(Telescope):
                          0.079789755, 0.077237853, 0.074972054, 0.072399174,
                          0.069519165, 0.066662492, 0.063829159, 0.061106831,
                          0.058511426, 0.057261531, 0.057550245])
-    
+
     def __init__(self, x=_x, y=_y, z=_z, theta=_theta, alt=None, az=_az,
                  tel_type = 'IACT', efficiency=None, apert=None, area=None,
                  N_pix=None, int_time=None):


### PR DESCRIPTION
We will use readthedocs instead (https://readthedocs.org/projects/showermodel/).

Links to the new docs web (https://showermodel.readthedocs.io/) are also changed.