### PR TITLE
Add package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(
             'extra/Edep_profile_1000GeV_1000sh_0deg.dat',
             'extra/mean_annual_global_reference_atmosphere.xlsx',
             'extra/showermodel_config.toml',
-            'extra/tel_data.toml'
+            'extra/tel_data.toml',
+            'showermodel/constants/*.toml',
         ],
     },
     # here are optional dependencies (as "tag" : "dependency spec")

--- a/showermodel/tests/test_telescope.py
+++ b/showermodel/tests/test_telescope.py
@@ -1,11 +1,10 @@
 def test_telescope():
-    from showermodel import IACT
+    from showermodel.telescope import Telescope
 
     # Default telescope type: IACT
     # Default angular aperture in degrees: 8.0
     # Default detection area in m2: 113.097
-    telescope = IACT()
-    assert telescope.tel_type == 'IACT'
-    assert telescope.apert == 8.0
-    assert telescope.area == 113.097
-
+    telescope = Telescope()
+    assert telescope.tel_type == 'generic'
+    assert telescope.apert == 10.0
+    assert telescope.area == 100.0


### PR DESCRIPTION
I think toml files within the constant folder were not included when installing the library in the GH actions CI workflow. I added them to the `package_data` in `setup.py` so they are included when installing the package.

I also updated the tests for the `Telescope` class since IACT does not exist anymore.